### PR TITLE
Fix Makefiles to success make command.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ all: test example
 .PHONY: lib test install uninstall run
 
 test: lib
-	make -C test all
+	make -C test
 
 lib:
 	make -C lib

--- a/test/Makefile
+++ b/test/Makefile
@@ -1,6 +1,6 @@
 
 CFLAGS += \
-	-I. -g -O0 -pthread \
+	-I. -I../lib -g -O0 -pthread \
 	-I/usr/include \
 	-I/usr/local/include \
 	-I/usr/local/include/wireshark \
@@ -8,6 +8,7 @@ CFLAGS += \
 	-I/usr/include/glib-2.0
 CXXFLAGS += $(CFLAGS) -std=c++11
 LDFLAGS +=  \
+  -L../lib \
 	-L/usr/local/lib \
 	-pthread \
 	-lgthread-2.0 \


### PR DESCRIPTION
Modified two Makefiles

- **Makefile**
test/Makefile does not have `all` target, so remove it (or it may be better to replace it with another target)
- **test/Makefile**
to build library, add the `lib` directory to CFLAGS and LDFLAGS.